### PR TITLE
chore(provider): bump github provider v2.3.0

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -10,5 +10,5 @@ terraform {
 }
 
 provider "github" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
 }


### PR DESCRIPTION
## Description

Bump github provider to v2.3.0 

## Breaking Changes

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root directory (look in CI for an example)
* [ ] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the breaking changes section above
