### PR TITLE
feat(user,team,repo): update thomas pejout permissions

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -71,7 +71,7 @@ module "blog_eleven-labs_com" {
       pr_reviews-required_approving_review_count = 1
       pr_reviews-require_code_owner_reviews      = false
       pr_reviews-dismiss_stale_reviews           = false
-      pr_reviews-dismissal_users                 = []
+      pr_reviews-dismissal_users                 = [module.PEJOUTThomas.login]
       pr_reviews-dismissal_teams                 = []
       restrictions-users = [
         module.PEJOUTThomas.login,
@@ -118,9 +118,9 @@ module "codelabs" {
       pr_reviews-required_approving_review_count = 1
       pr_reviews-require_code_owner_reviews      = false
       pr_reviews-dismiss_stale_reviews           = false
-      pr_reviews-dismissal_users                 = []
+      pr_reviews-dismissal_users                 = [module.PEJOUTThomas.login]
       pr_reviews-dismissal_teams                 = []
-      restrictions-users                         = []
+      restrictions-users                         = [module.PEJOUTThomas.login]
       restrictions-teams                         = []
     }
   ]

--- a/teams.tf
+++ b/teams.tf
@@ -170,7 +170,7 @@ module "hq" {
     (module.AMARBenjamin.login) = "member",
     (module.BERRYElsa.login)    = "member",
     (module.CLAVIERAnais.login) = "member",
-    (module.PEJOUTThomas.login) = "maintainer",
+    (module.PEJOUTThomas.login) = "member",
     (module.WILSON.login)       = "member",
   }
 }

--- a/users.tf
+++ b/users.tf
@@ -387,7 +387,7 @@ module "PEJOUTThomas" {
   source = "./module/user/"
 
   user-name = "ElevenTom"
-  user-role = "admin"
+  user-role = "member"
 }
 
 # PIERLOT Romain


### PR DESCRIPTION
## Description

- update user `ElevenTom` from `admin` to `member` of the `eleven-labs` organization
- update user `ElevenTom` from `maintainer` to `member` of the `hq` team
- update repository `blog.eleven-labs.com` to allow `ElevenTom` on `pr_reviews-dismissal`
- update repository `codelabs` to allow `ElevenTom` on `pr_reviews-dismissal` & `restrictions-users`

## Breaking Changes

~

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root directory (look in CI for an example)
* [ ] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the breaking changes section above
