### PR TITLE
refactor(team): rename team-roles variable to team-members_role

### DIFF
--- a/module/team/main.tf
+++ b/module/team/main.tf
@@ -11,5 +11,5 @@ resource "github_team_membership" "members" {
 
   team_id  = github_team.main.id
   username = each.value
-  role     = var.team-roles[each.value]
+  role     = var.team-members_role[each.value]
 }

--- a/module/team/variables.tf
+++ b/module/team/variables.tf
@@ -33,7 +33,7 @@ variable "team-members" {
 }
 
 
-variable "team-roles" {
+variable "team-members_role" {
   type = map
 
   default = {}

--- a/teams.tf
+++ b/teams.tf
@@ -16,7 +16,7 @@ module "core" {
     module.VEBERArnaud.login,
   ]
 
-  team-roles = {
+  team-members_role = {
     (module.GORRONCharlesEric.login) = "maintainer",
     (module.GREAUXJeremy.login)      = "maintainer",
     (module.JARDINETRemy.login)      = "maintainer",
@@ -92,7 +92,7 @@ module "developers" {
     module.VERMEILPierre.login,
   ]
 
-  team-roles = {
+  team-members_role = {
     (module.ALGRINThibaut.login)          = "member",
     (module.ANDREAlexandre.login)         = "member",
     (module.BENAIMMichael.login)          = "member",
@@ -166,7 +166,7 @@ module "hq" {
     module.WILSON.login,
   ]
 
-  team-roles = {
+  team-members_role = {
     (module.AMARBenjamin.login) = "member",
     (module.BERRYElsa.login)    = "member",
     (module.CLAVIERAnais.login) = "member",


### PR DESCRIPTION
## Description

- rename `team` module variable `team-roles` to `team-members_role`

## Breaking Changes

~

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root directory (look in CI for an example)
* [ ] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the breaking changes section above
