### PR TITLE
refactor(repository): module outputs naming

### DIFF
--- a/module/repository/outputs.tf
+++ b/module/repository/outputs.tf
@@ -1,20 +1,20 @@
-output "repository-full_name" {
+output "full_name" {
   value = github_repository.main.full_name
 }
 
-output "repository-html_url" {
+output "html_url" {
   value = github_repository.main.html_url
 }
 
-output "repository-ssh_clone_url" {
+output "ssh_clone_url" {
   value = github_repository.main.ssh_clone_url
 }
 
-output "repository-http_clone_url" {
+output "http_clone_url" {
   value = github_repository.main.http_clone_url
 }
 
-output "repository-svn_url" {
+output "svn_url" {
   value = github_repository.main.svn_url
 }
 


### PR DESCRIPTION
## Description

- rename `repository` module outputs to be consistent with other module

## Breaking Changes

- `module.<repository>.repository-full_name` -> `module.<repository>.full_name`
- `module.<repository>.repository-html_url ` -> `module.<repository>.html_url `
- `module.<repository>.repository-ssh_clone_url ` -> `module.<repository>.ssh_clone_url `
- `module.<repository>.repository-http_clone_url ` -> `module.<repository>.http_clone_url `
- `module.<repository>.repository-svn_url ` -> `module.<repository>.svn_url `

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root directory (look in CI for an example)
* [ ] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the breaking changes section above
