### PR TITLE
feat(team): team repository permissions

### DIFF
--- a/module/repository/outputs.tf
+++ b/module/repository/outputs.tf
@@ -1,3 +1,7 @@
+output "name" {
+  value = github_repository.main.name
+}
+
 output "full_name" {
   value = github_repository.main.full_name
 }

--- a/module/team/main.tf
+++ b/module/team/main.tf
@@ -13,3 +13,11 @@ resource "github_team_membership" "members" {
   username = each.value
   role     = var.team-members_role[each.value]
 }
+
+resource "github_team_repository" "repositories" {
+  for_each = toset(var.team-repositories)
+
+  team_id    = github_team.main.id
+  repository = each.value
+  permission = var.team-repositories_permission[each.value]
+}

--- a/module/team/variables.tf
+++ b/module/team/variables.tf
@@ -38,3 +38,16 @@ variable "team-members_role" {
 
   default = {}
 }
+
+variable "team-repositories" {
+  type = list(string)
+
+  default = []
+}
+
+
+variable "team-repositories_permission" {
+  type = map
+
+  default = {}
+}

--- a/teams.tf
+++ b/teams.tf
@@ -25,6 +25,20 @@ module "core" {
     (module.SAILLARDDamien11.login)  = "maintainer",
     (module.VEBERArnaud.login)       = "maintainer",
   }
+
+  team-repositories = [
+    module.github.name,
+    module.blog_eleven-labs_com.name,
+    module.codelabs.name,
+    module.wheel-of-fortune.name,
+  ]
+
+  team-repositories_permission = {
+    (module.github.name)               = "admin",
+    (module.blog_eleven-labs_com.name) = "admin",
+    (module.codelabs.name)             = "admin",
+    (module.wheel-of-fortune.name)     = "admin",
+  }
 }
 
 # Developers
@@ -148,6 +162,20 @@ module "developers" {
     (module.VEBERArnaud.login)            = "maintainer",
     (module.VERMEILPierre.login)          = "member",
   }
+
+  team-repositories = [
+    module.github.name,
+    module.blog_eleven-labs_com.name,
+    module.codelabs.name,
+    module.wheel-of-fortune.name,
+  ]
+
+  team-repositories_permission = {
+    (module.github.name)               = "push",
+    (module.blog_eleven-labs_com.name) = "push",
+    (module.codelabs.name)             = "push",
+    (module.wheel-of-fortune.name)     = "push",
+  }
 }
 
 # HQ
@@ -172,5 +200,19 @@ module "hq" {
     (module.CLAVIERAnais.login) = "member",
     (module.PEJOUTThomas.login) = "member",
     (module.WILSON.login)       = "member",
+  }
+
+  team-repositories = [
+    module.github.name,
+    module.blog_eleven-labs_com.name,
+    module.codelabs.name,
+    module.wheel-of-fortune.name,
+  ]
+
+  team-repositories_permission = {
+    (module.github.name)               = "pull",
+    (module.blog_eleven-labs_com.name) = "push",
+    (module.codelabs.name)             = "push",
+    (module.wheel-of-fortune.name)     = "push",
   }
 }


### PR DESCRIPTION
## Description

- handle `team` repository permissions
- add output for `repository` name
- update teams definition to add repository permissions

## Breaking Changes

~

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root directory (look in CI for an example)
* [ ] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the breaking changes section above
