### PR TITLE
feat(repo,team): api-validator repo

### DIFF
--- a/.envrc.dist
+++ b/.envrc.dist
@@ -3,3 +3,5 @@ export AWS_DEFAULT_REGION=
 
 export GITHUB_TOKEN=
 export GITHUB_ORGANIZATION=
+
+export TF_VAR_packagist_token=

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -12,6 +12,7 @@ env:
   AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
   GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
   GITHUB_ORGANIZATION: ${{ secrets.CUSTOM_GITHUB_ORGANIZATION }}
+  TF_VAR_packagist_token: ${{ secrets.PACKAGIST_TOKEN }}
 
 jobs:
   terraform:

--- a/repositories.tf
+++ b/repositories.tf
@@ -35,6 +35,52 @@ module "github" {
   repository-issue_labels = concat(var.default-issue_labels)
 }
 
+module "api-validator" {
+  source = "./module/repository/"
+
+  # repository
+  repository-name        = "api-validator"
+  repository-description = "Provide helpers that validate a request against an OpenAPi/Swagger2 API description"
+
+  repository-private = false
+
+  repository-has_projects = false
+
+  repository-auto_init      = false
+  repository-default_branch = "master"
+
+  # webhooks
+  webhooks = [
+    {
+      url          = "https://notify.travis-ci.org"
+      secret       = null
+      content_type = "form"
+      insecure_ssl = false
+      active       = true
+      events       = ["create", "delete", "issue_comment", "member", "public", "pull_request", "push", "repository"]
+    },
+    {
+      url          = "https://scrutinizer-ci.com/github-callback"
+      secret       = null
+      content_type = "json"
+      insecure_ssl = false
+      active       = true
+      events       = ["commit_comment", "issue_comment", "pull_request", "pull_request_review_comment", "push", "status"]
+    },
+    {
+      url          = "https://packagist.org/api/update-package?username=guillemcanal"
+      secret       = null
+      content_type = "json"
+      insecure_ssl = false
+      active       = true
+      events       = ["push"]
+      secret       = var.packagist_token
+    }
+  ]
+
+  repository-issue_labels = concat(var.default-issue_labels)
+}
+
 module "amp-jekyll" {
   source = "./module/repository/"
 

--- a/teams.tf
+++ b/teams.tf
@@ -28,6 +28,7 @@ module "core" {
 
   team-repositories = [
     module.github.name,
+    module.api-validator.name,
     module.amp-jekyll.name,
     module.blog_eleven-labs_com.name,
     module.codelabs.name,
@@ -38,6 +39,7 @@ module "core" {
 
   team-repositories_permission = {
     (module.github.name)                           = "admin",
+    (module.api-validator.name)                    = "admin",
     (module.amp-jekyll.name)                       = "admin",
     (module.blog_eleven-labs_com.name)             = "admin",
     (module.codelabs.name)                         = "admin",
@@ -183,6 +185,7 @@ module "developers" {
 
   team-repositories = [
     module.github.name,
+    module.api-validator.name,
     module.amp-jekyll.name,
     module.blog_eleven-labs_com.name,
     module.codelabs.name,
@@ -193,6 +196,7 @@ module "developers" {
 
   team-repositories_permission = {
     (module.github.name)                           = "push",
+    (module.api-validator.name)                    = "push",
     (module.amp-jekyll.name)                       = "push",
     (module.blog_eleven-labs_com.name)             = "push",
     (module.codelabs.name)                         = "push",
@@ -228,6 +232,7 @@ module "hq" {
 
   team-repositories = [
     module.github.name,
+    module.api-validator.name,
     module.amp-jekyll.name,
     module.blog_eleven-labs_com.name,
     module.codelabs.name,
@@ -238,6 +243,7 @@ module "hq" {
 
   team-repositories_permission = {
     (module.github.name)                           = "pull",
+    (module.api-validator.name)                    = "push",
     (module.amp-jekyll.name)                       = "push",
     (module.blog_eleven-labs_com.name)             = "push",
     (module.codelabs.name)                         = "push",

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,7 @@ variable "default-issue_labels" {
     }
   ]
 }
+
+variable "packagist_token" {
+  type = string
+}


### PR DESCRIPTION
## Description

Retrieve `api-validator` repository
Set teams permissions on `api-validator` repository

## Breaking Changes

~

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root directory (look in CI for an example)
* [x] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the breaking changes section above
