### PR TITLE
feat(repo,blog): remove travis from status check

### DIFF
--- a/repositories.tf
+++ b/repositories.tf
@@ -121,7 +121,7 @@ module "blog_eleven-labs_com" {
       enforce_admins                             = false
       require_signed_commits                     = false
       status_check-strict                        = true
-      status_check-contexts                      = ["Travis CI - Branch", "Travis CI - Pull Request"]
+      status_check-contexts                      = []
       pr_reviews-required_approving_review_count = 1
       pr_reviews-require_code_owner_reviews      = false
       pr_reviews-dismiss_stale_reviews           = false

--- a/repositories.tf
+++ b/repositories.tf
@@ -121,7 +121,7 @@ module "blog_eleven-labs_com" {
       enforce_admins                             = false
       require_signed_commits                     = false
       status_check-strict                        = true
-      status_check-contexts                      = []
+      status_check-contexts                      = ["deploy"]
       pr_reviews-required_approving_review_count = 1
       pr_reviews-require_code_owner_reviews      = false
       pr_reviews-dismiss_stale_reviews           = false


### PR DESCRIPTION
## Description

Remove travis form status check for repository `blog.eleven-labs.com`

## Breaking Changes

~

### Checklist

* [x] `terraform fmt` and `terraform validate` both work from the root directory (look in CI for an example)
* [x] Docs have been added/updated (for bug fixes/features)
* [x] Any breaking changes are noted in the breaking changes section above
